### PR TITLE
DM-35383: automatically import lsst.ts.ess.labjack if LabJackAccelerometerDataClient is retrieved from the registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,6 @@
 .sconsign.dblite
-config.log
 .sconf_temp
-*.o
-*.os
-*.so
-*.cfgc
-*.pyc
-*_wrap.cc
-*Lib.py
+*.log
 
 # Built by sconsUtils
 version.py
@@ -19,3 +12,7 @@ pytest_session.txt
 .cache/
 .pytest_cache
 .coverage
+.hypothesis
+
+# Editors
+.vscode

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,12 @@
 Version History
 ###############
 
+v0.7.5
+======
+
+* `ExternalDataClientModules`: add ``LabJackAccelerometerDataClient`` so lsst.ts.labjack is imported if needed.
+* Modernize type annotations for Python 3.10.
+
 v0.7.4
 ======
 

--- a/python/lsst/ts/ess/common/abstract_command_handler.py
+++ b/python/lsst/ts/ess/common/abstract_command_handler.py
@@ -21,9 +21,10 @@
 
 __all__ = ["AbstractCommandHandler"]
 
+from collections.abc import Callable
 from abc import ABC, abstractmethod
 import logging
-import typing
+from typing import Any
 
 import jsonschema
 
@@ -64,7 +65,7 @@ class AbstractCommandHandler(ABC):
 
     valid_simulation_modes = (0, 1)
 
-    def __init__(self, callback: typing.Callable, simulation_mode: int) -> None:
+    def __init__(self, callback: Callable, simulation_mode: int) -> None:
         self.log = logging.getLogger(type(self).__name__)
         if simulation_mode not in self.valid_simulation_modes:
             raise ValueError(
@@ -75,16 +76,16 @@ class AbstractCommandHandler(ABC):
         self.simulation_mode = simulation_mode
 
         self._callback = callback
-        self.configuration: typing.Optional[typing.Dict[str, typing.Any]] = None
+        self.configuration: None | dict[str, Any] = None
         self._started = False
 
-        self.devices: typing.List[BaseDevice] = []
+        self.devices: list[BaseDevice] = []
 
-        self.dispatch_dict: typing.Dict[str, typing.Callable] = {
+        self.dispatch_dict: dict[str, Callable] = {
             Command.CONFIGURE: self.configure,
         }
 
-    async def handle_command(self, command: str, **kwargs: typing.Any) -> None:
+    async def handle_command(self, command: str, **kwargs: Any) -> None:
         """Handle incomming commands and parameters.
 
         Parameters
@@ -107,9 +108,7 @@ class AbstractCommandHandler(ABC):
             raise
         await self._callback(response)
 
-    def _validate_configuration(
-        self, configuration: typing.Dict[str, typing.Any]
-    ) -> None:
+    def _validate_configuration(self, configuration: dict[str, Any]) -> None:
         """Validate the configuration.
 
         Parameters
@@ -133,7 +132,7 @@ class AbstractCommandHandler(ABC):
                 response_code=ResponseCode.INVALID_CONFIGURATION,
             )
 
-    async def configure(self, configuration: typing.Dict[str, typing.Any]) -> None:
+    async def configure(self, configuration: dict[str, Any]) -> None:
         """Apply the configuration and start sending telemetry.
 
         Parameters
@@ -194,9 +193,7 @@ class AbstractCommandHandler(ABC):
         self._started = False
 
     @abstractmethod
-    def create_device(
-        self, device_configuration: typing.Dict[str, typing.Any]
-    ) -> BaseDevice:
+    def create_device(self, device_configuration: dict[str, Any]) -> BaseDevice:
         """Create the device to connect to by using the specified
         configuration.
 

--- a/python/lsst/ts/ess/common/base_data_client.py
+++ b/python/lsst/ts/ess/common/base_data_client.py
@@ -48,6 +48,7 @@ _DataClientClassRegistry: Dict[str, Type[BaseDataClient]] = dict()
 # because the ESS CSC already imports those two modules.
 ExternalDataClientModules = dict(
     LabJackDataClient="lsst.ts.ess.labjack",
+    LabJackAccelerometerDataClient="lsst.ts.ess.labjack",
 )
 
 

--- a/python/lsst/ts/ess/common/base_data_client.py
+++ b/python/lsst/ts/ess/common/base_data_client.py
@@ -86,8 +86,8 @@ class BaseDataClient(abc.ABC):
 
     Parameters
     ----------
-    name : str
-    config : types.SimpleNamespace
+    name : `str`
+    config : `types.SimpleNamespace`
         The configuration, after validation by the schema returned
         by `get_config_schema` and conversion to a types.SimpleNamespace.
     topics : `salobj.Controller`

--- a/python/lsst/ts/ess/common/base_data_client.py
+++ b/python/lsst/ts/ess/common/base_data_client.py
@@ -32,16 +32,15 @@ import importlib
 import inspect
 import logging
 import types
-from typing import Any, Dict, Type, Union, TYPE_CHECKING
+from typing import Any, Type
 
-if TYPE_CHECKING:
-    from lsst.ts import salobj
+from lsst.ts import salobj
 from lsst.ts import utils
 
 # Dict of data client class name: data client class.
 # Access via the `get_data_client_class functions`.
 # BaseDataClient automatically registers concrete subclasses.
-_DataClientClassRegistry: Dict[str, Type[BaseDataClient]] = dict()
+_DataClientClassRegistry: dict[str, Type[BaseDataClient]] = dict()
 
 # Dict of data client class name: name of module in which it is defined.
 # You may omit data clients found in ts_ess_common and ts_ess_csc,
@@ -92,8 +91,8 @@ class BaseDataClient(abc.ABC):
         The configuration, after validation by the schema returned
         by `get_config_schema` and conversion to a types.SimpleNamespace.
     topics : `salobj.Controller`
-        The telemetry topics this data client can write,
-        as a struct with attributes such as ``tel_temperature``.
+        The telemetry topics this model can write, as a struct with attributes
+        such as ``tel_temperature``.
     log : `logging.Logger`
         Logger.
     simulation_mode : `int`, optional
@@ -103,7 +102,7 @@ class BaseDataClient(abc.ABC):
     def __init__(
         self,
         config: types.SimpleNamespace,
-        topics: Union[salobj.Controller, types.SimpleNamespace],
+        topics: salobj.Controller | types.SimpleNamespace,
         log: logging.Logger,
         simulation_mode: int = 0,
     ) -> None:
@@ -117,7 +116,7 @@ class BaseDataClient(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def get_config_schema(cls) -> Dict[str, Any]:
+    def get_config_schema(cls) -> dict[str, Any]:
         """Get the config schema as jsonschema dict."""
         raise NotImplementedError()
 

--- a/python/lsst/ts/ess/common/device/base_device.py
+++ b/python/lsst/ts/ess/common/device/base_device.py
@@ -25,9 +25,10 @@ __all__ = ["BaseDevice", "BAUDRATE"]
 
 from abc import ABC, abstractmethod
 import asyncio
+from collections.abc import Callable
 import logging
 import types
-import typing
+from typing import Type
 
 from ..constants import Key, ResponseCode
 from ..sensor import BaseSensor
@@ -65,13 +66,13 @@ class BaseDevice(ABC):
         name: str,
         device_id: str,
         sensor: BaseSensor,
-        callback_func: typing.Callable,
+        callback_func: Callable,
         log: logging.Logger,
     ) -> None:
         self.name: str = name
         self.device_id: str = device_id
         self.sensor: BaseSensor = sensor
-        self._callback_func: typing.Callable = callback_func
+        self._callback_func: Callable = callback_func
         self._telemetry_loop: asyncio.Future = utils.make_done_future()
         self.is_open = False
         self.log = log.getChild(type(self).__name__)
@@ -85,9 +86,9 @@ class BaseDevice(ABC):
 
     async def __aexit__(
         self,
-        type: typing.Optional[typing.Type[BaseException]],
-        value: typing.Optional[BaseException],
-        traceback: typing.Optional[types.TracebackType],
+        type: None | Type[BaseException],
+        value: None | BaseException,
+        traceback: None | types.TracebackType,
     ) -> None:
         await self.close()
 

--- a/python/lsst/ts/ess/common/device/mock_device.py
+++ b/python/lsst/ts/ess/common/device/mock_device.py
@@ -22,8 +22,9 @@
 __all__ = ["MockDevice"]
 
 import asyncio
+from collections.abc import Callable
 import logging
-import typing
+from typing import Type
 
 from .base_device import BaseDevice
 from .mock_formatter import MockFormatter
@@ -57,7 +58,7 @@ class MockDevice(BaseDevice):
         name: str,
         device_id: str,
         sensor: BaseSensor,
-        callback_func: typing.Callable,
+        callback_func: Callable,
         log: logging.Logger,
     ) -> None:
         super().__init__(
@@ -85,7 +86,7 @@ class MockDevice(BaseDevice):
         self.in_error_state = False
 
         # Registry of formatters for the different types of sensors.
-        self.formatter_registry: typing.Dict[typing.Type[BaseSensor], MockFormatter] = {
+        self.formatter_registry: dict[Type[BaseSensor], MockFormatter] = {
             Hx85aSensor: MockHx85aFormatter(),
             Hx85baSensor: MockHx85baFormatter(),
             TemperatureSensor: MockTemperatureFormatter(),

--- a/python/lsst/ts/ess/common/device/mock_formatter.py
+++ b/python/lsst/ts/ess/common/device/mock_formatter.py
@@ -29,7 +29,6 @@ __all__ = [
 
 from abc import ABC, abstractmethod
 import types
-import typing
 
 # The minimum and maximum temperatures [ºC] used by the mock device.
 MockTemperatureConfig = types.SimpleNamespace(min=18.0, max=30.0)
@@ -53,7 +52,7 @@ class MockFormatter(ABC):
         num_channels: int = 0,
         disconnected_channel: int = 0,
         missed_channels: int = 0,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         """Create a formatted output of a sensor.
 
         Parameters

--- a/python/lsst/ts/ess/common/device/mock_hx85_formatter.py
+++ b/python/lsst/ts/ess/common/device/mock_hx85_formatter.py
@@ -22,7 +22,6 @@
 __all__ = ["MockHx85baFormatter", "MockHx85aFormatter"]
 
 import random
-import typing
 
 from .mock_formatter import (
     MockFormatter,
@@ -75,7 +74,7 @@ class MockHx85aFormatter(MockFormatter):
         num_channels: int = 0,
         disconnected_channel: int = 0,
         missed_channels: int = 0,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         return [
             format_hbx85_humidity(index=0, missed_channels=missed_channels),
             format_hbx85_temperature(index=1, missed_channels=missed_channels),
@@ -89,7 +88,7 @@ class MockHx85baFormatter(MockFormatter):
         num_channels: int = 0,
         disconnected_channel: int = 0,
         missed_channels: int = 0,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         return [
             format_hbx85_humidity(index=0, missed_channels=missed_channels),
             format_hbx85_temperature(index=1, missed_channels=missed_channels),

--- a/python/lsst/ts/ess/common/device/mock_temperature_formatter.py
+++ b/python/lsst/ts/ess/common/device/mock_temperature_formatter.py
@@ -23,8 +23,6 @@ __all__ = ["MockTemperatureFormatter"]
 
 import random
 
-import typing
-
 from ..constants import DISCONNECTED_VALUE
 from .mock_formatter import MockFormatter, MockTemperatureConfig
 
@@ -58,7 +56,7 @@ class MockTemperatureFormatter(MockFormatter):
         num_channels: int = 0,
         disconnected_channel: int = -1,
         missed_channels: int = 0,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         output = [
             format_temperature(i, disconnected_channel, missed_channels)
             for i in range(0, num_channels)

--- a/python/lsst/ts/ess/common/device_config.py
+++ b/python/lsst/ts/ess/common/device_config.py
@@ -21,8 +21,6 @@
 
 __all__ = ["DeviceConfig"]
 
-from typing import Dict, Union
-
 from .constants import DeviceType, Key, SensorType
 
 
@@ -62,7 +60,7 @@ class DeviceConfig:
         self.sens_type = SensorType(sens_type)
         self.location = location
 
-    def as_dict(self) -> Dict[str, Union[str, int]]:
+    def as_dict(self) -> dict[str, str | int]:
         """Return a dict with the instance attributes and their values as
         key-value pairs.
 
@@ -72,7 +70,7 @@ class DeviceConfig:
             A dictionary of key-value pairs representing the instance
             attributes and their values.
         """
-        device_config_as_dict: Dict[str, Union[str, int]] = {
+        device_config_as_dict: dict[str, str | int] = {
             Key.NAME: self.name,
             Key.DEVICE_TYPE: self.dev_type,
             Key.SENSOR_TYPE: self.sens_type,

--- a/python/lsst/ts/ess/common/mock_command_handler.py
+++ b/python/lsst/ts/ess/common/mock_command_handler.py
@@ -21,7 +21,7 @@
 
 __all__ = ["MockCommandHandler"]
 
-import typing
+from typing import Any
 
 from .abstract_command_handler import AbstractCommandHandler
 from .constants import Key
@@ -30,9 +30,7 @@ from .sensor import create_sensor
 
 
 class MockCommandHandler(AbstractCommandHandler):
-    def create_device(
-        self, device_configuration: typing.Dict[str, typing.Any]
-    ) -> BaseDevice:
+    def create_device(self, device_configuration: dict[str, Any]) -> BaseDevice:
         """Create the device to connect to by using the specified
         configuration.
 

--- a/python/lsst/ts/ess/common/mock_data_client.py
+++ b/python/lsst/ts/ess/common/mock_data_client.py
@@ -26,12 +26,11 @@ __all__ = ["MockDataClient"]
 import asyncio
 import logging
 import types
-from typing import Any, Dict, Optional, Union, TYPE_CHECKING
+from typing import Any
 
 import yaml
 
-if TYPE_CHECKING:
-    from lsst.ts import salobj
+from lsst.ts import salobj
 from .base_data_client import BaseDataClient
 
 
@@ -41,23 +40,23 @@ class MockDataClient(BaseDataClient):
     def __init__(
         self,
         config: types.SimpleNamespace,
-        topics: Union[salobj.Controller, types.SimpleNamespace],
+        topics: salobj.Controller | types.SimpleNamespace,
         log: logging.Logger,
         simulation_mode: int = 0,
     ) -> None:
         self.connected = False
         # Exceptions to raise in the specified methods, or None to not raise.
         # Set to an *instance* of an exception, not a class.
-        self.connect_exception: Optional[Exception] = None
-        self.disconnect_exception: Optional[Exception] = None
-        self.run_exception: Optional[Exception] = None
+        self.connect_exception: None | Exception = None
+        self.disconnect_exception: None | Exception = None
+        self.run_exception: None | Exception = None
         self.num_run = 0
         super().__init__(
             config=config, topics=topics, log=log, simulation_mode=simulation_mode
         )
 
     @classmethod
-    def get_config_schema(cls) -> Dict[str, Any]:
+    def get_config_schema(cls) -> dict[str, Any]:
         """Return a schema.
 
         The schema is ignored in this unit test, as it is applied

--- a/python/lsst/ts/ess/common/sensor/base_sensor.py
+++ b/python/lsst/ts/ess/common/sensor/base_sensor.py
@@ -23,7 +23,6 @@ __all__ = ["BaseSensor"]
 
 from abc import ABC, abstractmethod
 import logging
-from typing import List
 
 
 class BaseSensor(ABC):
@@ -57,7 +56,7 @@ class BaseSensor(ABC):
         self.charset = "ASCII"
 
     @abstractmethod
-    async def extract_telemetry(self, line: str) -> List[float]:
+    async def extract_telemetry(self, line: str) -> list[float]:
         """Extract the telemetry from a line of Sensor data.
 
         Returns

--- a/python/lsst/ts/ess/common/sensor/omega_hx85a.py
+++ b/python/lsst/ts/ess/common/sensor/omega_hx85a.py
@@ -23,7 +23,6 @@ __all__ = ["Hx85aSensor"]
 
 import logging
 import math
-import typing
 
 from .base_sensor import BaseSensor
 from ..constants import SensorType
@@ -74,7 +73,7 @@ class Hx85aSensor(BaseSensor):
         # Override default value.
         self.charset = "ISO-8859-1"
 
-    async def extract_telemetry(self, line: str) -> typing.List[float]:
+    async def extract_telemetry(self, line: str) -> list[float]:
         """Extract the telemetry from a line of Sensor data.
 
         Parameters

--- a/python/lsst/ts/ess/common/sensor/omega_hx85ba.py
+++ b/python/lsst/ts/ess/common/sensor/omega_hx85ba.py
@@ -23,7 +23,6 @@ __all__ = ["Hx85baSensor"]
 
 import logging
 import math
-from typing import List
 
 from .base_sensor import BaseSensor
 from ..constants import SensorType
@@ -109,7 +108,7 @@ class Hx85baSensor(BaseSensor):
         # Return the value truncated at two decimals.
         return λ * f / (β - f)
 
-    async def extract_telemetry(self, line: str) -> List[float]:
+    async def extract_telemetry(self, line: str) -> list[float]:
         """Extract the telemetry from a line of Sensor data.
 
         Parameters

--- a/python/lsst/ts/ess/common/sensor/sensor_registry.py
+++ b/python/lsst/ts/ess/common/sensor/sensor_registry.py
@@ -22,24 +22,22 @@
 __all__ = ["sensor_registry", "register_sensor", "create_sensor"]
 
 import logging
-import typing
+from typing import Any, Type
 
 from .base_sensor import BaseSensor
 from ..constants import Key, SensorType
 
-sensor_registry: typing.Dict[SensorType, typing.Type[BaseSensor]] = dict()
+sensor_registry: dict[SensorType, Type[BaseSensor]] = dict()
 
 
-def register_sensor(
-    sensor_type: SensorType, sensor_class: typing.Type[BaseSensor]
-) -> None:
+def register_sensor(sensor_type: SensorType, sensor_class: Type[BaseSensor]) -> None:
     """Register a BaseSensor subclass against a SensorType.
 
     Parameters
     ----------
     sensor_type : `SensorType`
         The SensorType to register against.
-    sensor_class : `typing.Type`
+    sensor_class : `Type`
         The BaseSensor subclass to register.
 
     Raises
@@ -60,7 +58,7 @@ def register_sensor(
 
 
 def create_sensor(
-    device_configuration: typing.Dict[str, typing.Any], log: logging.Logger
+    device_configuration: dict[str, Any], log: logging.Logger
 ) -> BaseSensor:
     """Create the sensor to connect to by using the specified
     configuration.

--- a/python/lsst/ts/ess/common/sensor/temperature_sensor.py
+++ b/python/lsst/ts/ess/common/sensor/temperature_sensor.py
@@ -23,7 +23,6 @@ __all__ = ["TemperatureSensor"]
 
 import logging
 import math
-from typing import List
 
 from .base_sensor import BaseSensor
 from ..constants import DISCONNECTED_VALUE, SensorType
@@ -65,7 +64,7 @@ class TemperatureSensor(BaseSensor):
     ) -> None:
         super().__init__(log=log, num_channels=num_channels)
 
-    async def extract_telemetry(self, line: str) -> List[float]:
+    async def extract_telemetry(self, line: str) -> list[float]:
         """Extract the temperature telemetry from a line of Sensor data.
 
         Parameters

--- a/python/lsst/ts/ess/common/sensor/utils.py
+++ b/python/lsst/ts/ess/common/sensor/utils.py
@@ -22,12 +22,9 @@
 __all__ = ["add_missing_telemetry"]
 
 import math
-import typing
 
 
-def add_missing_telemetry(
-    telemetry: typing.List[float], expected_length: int
-) -> typing.List[float]:
+def add_missing_telemetry(telemetry: list[float], expected_length: int) -> list[float]:
     """Prepend a telemetry list with NaN values to make sure that it has the
     expected length.
 

--- a/python/lsst/ts/ess/common/sensor/wind_sensor.py
+++ b/python/lsst/ts/ess/common/sensor/wind_sensor.py
@@ -33,7 +33,6 @@ __all__ = [
 import logging
 import math
 import re
-from typing import List
 
 from .base_sensor import BaseSensor
 from ..constants import SensorType
@@ -109,7 +108,7 @@ class WindSensor(BaseSensor):
             rf"{END_CHARACTER}(?P<checksum>[0-9a-fA-F]{{2}}){self.terminator}$"
         )
 
-    async def extract_telemetry(self, line: str) -> List[float]:
+    async def extract_telemetry(self, line: str) -> list[float]:
         """Extract the wind telemetry from a line of Sensor data.
 
         Parameters

--- a/python/lsst/ts/ess/common/socket_server.py
+++ b/python/lsst/ts/ess/common/socket_server.py
@@ -24,10 +24,10 @@ from __future__ import annotations
 __all__ = ["SocketServer"]
 
 import asyncio
+from collections.abc import Callable
 import json
 import logging
 import socket
-import typing
 
 from .abstract_command_handler import AbstractCommandHandler
 from lsst.ts import tcpip
@@ -61,11 +61,11 @@ class SocketServer(tcpip.OneClientServer):
     def __init__(
         self,
         name: str,
-        host: typing.Optional[str],
+        host: None | str,
         port: int,
         simulation_mode: int = 0,
         family: socket.AddressFamily = socket.AF_UNSPEC,
-        connect_callback: typing.Optional[typing.Callable] = None,
+        connect_callback: None | Callable = None,
     ) -> None:
         self.name = name
         if simulation_mode not in self.valid_simulation_modes:
@@ -77,7 +77,7 @@ class SocketServer(tcpip.OneClientServer):
         self.simulation_mode = simulation_mode
         self.read_loop_task: asyncio.Future = asyncio.Future()
         self.log: logging.Logger = logging.getLogger(type(self).__name__)
-        self.command_handler: typing.Optional[AbstractCommandHandler] = None
+        self.command_handler: None | AbstractCommandHandler = None
 
         if connect_callback is None:
             connect_callback = self.connect_callback

--- a/python/lsst/ts/ess/common/test_utils.py
+++ b/python/lsst/ts/ess/common/test_utils.py
@@ -22,7 +22,7 @@
 __all__ = ["MockTestTools", "SensorReply"]
 
 import math
-import typing
+from typing import TypedDict
 
 try:
     import pytest
@@ -36,8 +36,8 @@ except ImportError:
 from lsst.ts.ess import common
 
 
-class SensorReply(typing.TypedDict):
-    """`typing.TypedDict` for MyPy checking of sensor replies."""
+class SensorReply(TypedDict):
+    """`TypedDict` for MyPy checking of sensor replies."""
 
     name: str
     timestamp: float
@@ -56,7 +56,7 @@ class MockTestTools:
         device_name = reply["name"]
         time = float(reply["timestamp"])
         response_code = reply["response_code"]
-        resp: typing.List[float] = []
+        resp: list[float] = []
         for value in reply["sensor_telemetry"]:
             assert isinstance(value, float)
             resp.append(value)
@@ -92,7 +92,7 @@ class MockTestTools:
         device_name = reply["name"]
         time = float(reply["timestamp"])
         response_code = reply["response_code"]
-        resp: typing.List[float] = []
+        resp: list[float] = []
         for value in reply["sensor_telemetry"]:
             assert isinstance(value, float)
             resp.append(value)
@@ -138,7 +138,7 @@ class MockTestTools:
         device_name = reply["name"]
         time = float(reply["timestamp"])
         response_code = reply["response_code"]
-        resp: typing.List[float] = []
+        resp: list[float] = []
         for value in reply["sensor_telemetry"]:
             assert isinstance(value, float)
             resp.append(value)

--- a/tests/test_mock_command_handler.py
+++ b/tests/test_mock_command_handler.py
@@ -21,7 +21,7 @@
 
 import asyncio
 import logging
-import typing
+from typing import Any
 import unittest
 
 import pytest
@@ -40,7 +40,7 @@ TIMEOUT = 5
 class MockCommandHandlerTestCase(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         self.log = logging.getLogger(type(self).__name__)
-        self.responses: typing.List[typing.Dict[common.ResponseCode, typing.Any]] = []
+        self.responses: list[dict[common.ResponseCode, Any]] = []
         self.command_handler = common.MockCommandHandler(
             callback=self.callback, simulation_mode=1
         )
@@ -79,9 +79,7 @@ class MockCommandHandlerTestCase(unittest.IsolatedAsyncioTestCase):
             self.device_config_03.name: self.device_config_03,
         }
 
-    async def callback(
-        self, response: typing.Dict[common.ResponseCode, typing.Any]
-    ) -> None:
+    async def callback(self, response: dict[common.ResponseCode, Any]) -> None:
         self.responses.append(response)
 
     def validate_response(self, response_code: common.ResponseCode) -> None:
@@ -137,7 +135,7 @@ class MockCommandHandlerTestCase(unittest.IsolatedAsyncioTestCase):
         while len(self.responses) < len(self.device_configs):
             await asyncio.sleep(0.5)
 
-        devices_names_checked: typing.Set[str] = set()
+        devices_names_checked: set[str] = set()
         while len(devices_names_checked) != len(self.device_configs):
             reply = self.responses.pop()
             name = reply[common.Key.TELEMETRY][common.Key.NAME]

--- a/tests/test_mock_hb85a_device.py
+++ b/tests/test_mock_hb85a_device.py
@@ -21,7 +21,6 @@
 
 import asyncio
 import logging
-import typing
 import unittest
 
 from lsst.ts.ess import common
@@ -33,12 +32,8 @@ logging.basicConfig(
 
 
 class MockDeviceTestCase(unittest.IsolatedAsyncioTestCase):
-    async def _callback(
-        self, reply: typing.Dict[str, typing.List[typing.Union[str, float]]]
-    ) -> None:
-        self.reply: typing.Optional[
-            typing.Dict[str, typing.List[typing.Union[str, float]]]
-        ] = reply
+    async def _callback(self, reply: dict[str, list[str | float]]) -> None:
+        self.reply: None | dict[str, list[str | float]] = reply
 
     async def _check_mock_hx85a_device(
         self,

--- a/tests/test_mock_hb85ba_device.py
+++ b/tests/test_mock_hb85ba_device.py
@@ -21,7 +21,6 @@
 
 import asyncio
 import logging
-import typing
 import unittest
 
 from lsst.ts.ess import common
@@ -33,12 +32,8 @@ logging.basicConfig(
 
 
 class MockDeviceTestCase(unittest.IsolatedAsyncioTestCase):
-    async def _callback(
-        self, reply: typing.Dict[str, typing.List[typing.Union[str, float]]]
-    ) -> None:
-        self.reply: typing.Optional[
-            typing.Dict[str, typing.List[typing.Union[str, float]]]
-        ] = reply
+    async def _callback(self, reply: dict[str, list[str | float]]) -> None:
+        self.reply: None | dict[str, list[str | float]] = reply
 
     async def _check_mock_hx85ba_device(
         self,

--- a/tests/test_mock_temperature_device.py
+++ b/tests/test_mock_temperature_device.py
@@ -21,7 +21,6 @@
 
 import asyncio
 import logging
-import typing
 import unittest
 
 from lsst.ts.ess import common
@@ -33,12 +32,8 @@ logging.basicConfig(
 
 
 class MockDeviceTestCase(unittest.IsolatedAsyncioTestCase):
-    async def _callback(
-        self, reply: typing.Dict[str, typing.List[typing.Union[str, float]]]
-    ) -> None:
-        self.reply: typing.Optional[
-            typing.Dict[str, typing.List[typing.Union[str, float]]]
-        ] = reply
+    async def _callback(self, reply: dict[str, list[str | float]]) -> None:
+        self.reply: None | dict[str, list[str | float]] = reply
 
     async def _check_mock_temperature_device(
         self,

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -22,7 +22,7 @@
 import asyncio
 import json
 import logging
-import typing
+from typing import Any
 import unittest
 
 from lsst.ts import tcpip
@@ -70,7 +70,7 @@ class SocketServerTestCase(unittest.IsolatedAsyncioTestCase):
             await self.writer.wait_closed()
         await self.srv.exit()
 
-    async def read(self) -> typing.Dict[str, typing.Any]:
+    async def read(self) -> dict[str, Any]:
         """Read a string from the reader and unmarshal it
 
         Returns
@@ -84,7 +84,7 @@ class SocketServerTestCase(unittest.IsolatedAsyncioTestCase):
         data = json.loads(read_bytes.decode())
         return data
 
-    async def write(self, **data: typing.Dict[str, typing.Any]) -> None:
+    async def write(self, **data: dict[str, Any]) -> None:
         """Write the data appended with a tcpip.TERMINATOR string.
 
         Parameters


### PR DESCRIPTION
and modernize type annotations for Python 3.10