### PR TITLE
DM-49635 Fix for Python 3.12

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -47,6 +47,6 @@ requirements:
     - ts-xml
     - aioserial
     - jsonschema
-    - pysnmp =4.4.12
+    - pysnmp =7.1.16
     - pyasn1 =0.6.0
-    - pyasn1-modules =0.4.0
+    - pyasn1-modules =0.4.1

--- a/doc/snmp.rst
+++ b/doc/snmp.rst
@@ -129,9 +129,8 @@ All low level SNMP infrastrucuture is provided by the pysnmp_ project.
 That project uses pyasn1_ for its data types.
 Due to code reorganizations in both projects after SNMP support was added to ts_ess_common, both dependencies have been pinned to avoid pulling in the latest versions.
 
-SNMP supports getting telemetry via several commands which are all implemented in the `nextCmd` method of pysnmp.
-The `nextCmd` method takes several parameters, representing the host and port to connect to, the community data and the OID to query.
-Since the `nextCmd` method is synchronous, it needs to be wrapped in an asyncio `run_in_executor` call to not be blocking.
+SNMP supports getting telemetry via several commands which are all implemented in the `next_cmd` method of pysnmp.
+The `next_cmd` method takes several parameters, representing the host and port to connect to, the community data and the OID to query.
 
 The community data is a configurable string that is required and depends on the configuration of the SNMP device.
 By default it is set to `public` and for many SNMP devices at the summit it has been modified.

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,11 @@
 Version History
 ###############
 
+v0.20.1
+=======
+
+ * Fixed compatibility with pysnmp >= 5.0.0 for Python3.12.
+
 v0.20.0
 =======
 

--- a/python/lsst/ts/ess/common/snmp_server_simulator.py
+++ b/python/lsst/ts/ess/common/snmp_server_simulator.py
@@ -26,17 +26,31 @@ import random
 import string
 import typing
 
-from pysnmp.hlapi import (
-    CommunityData,
-    ContextData,
-    Integer,
-    ObjectIdentity,
-    ObjectType,
-    SnmpEngine,
-    UdpTransportTarget,
-)
+# TODO: DM-49666 After phase-out of Python3.11, remove the
+# conditional and the "else" block.
+import pysnmp
+from packaging import version
+
+if version.parse(pysnmp.__version__) >= version.parse("5.0.0"):
+    from pysnmp.hlapi.v3arch.asyncio import (
+        CommunityData,
+        ContextData,
+        ObjectIdentity,
+        ObjectType,
+        SnmpEngine,
+        UdpTransportTarget,
+    )
+else:
+    from pysnmp.hlapi import (
+        CommunityData,
+        ContextData,
+        ObjectIdentity,
+        ObjectType,
+        SnmpEngine,
+        UdpTransportTarget,
+    )
 from pysnmp.proto.rfc1155 import ObjectName
-from pysnmp.proto.rfc1902 import OctetString
+from pysnmp.proto.rfc1902 import Integer, OctetString
 
 from .mib_tree_holder import MibTreeHolder
 from .utils import (


### PR DESCRIPTION
This should fix the build for Python 3.12, which uses a newer version of pysnmp. Dummy TODO comments are included without matching tickets. After approval, I intend to create Jira tickets and then fill in the ticket number before merging.